### PR TITLE
updated about and doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ body.group-patrons div.donation-banner {
 
 ## Feedback
 
-If you have issues or suggestions for the plugin, please bring them up on
-[Discourse Meta](https://meta.discourse.org).
+If you have issues or suggestions for this theme component, please bring them up on
+[Discourse Meta](https://meta.discourse.org/t/css-classes-for-current-users-groups/226068).

--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
   "name": "discourse-groups-css-classes-in-body",
-  "about_url": "https://github.com/discourse/discourse-groups-css-classes-in-body",
+  "about_url": "https://meta.discourse.org/t/css-classes-for-current-users-groups/226068",
   "license_url": "https://github.com/discourse/discourse-groups-css-classes-in-body/blob/master/LICENSE",
   "component": true
 }


### PR DESCRIPTION
In Discourse's interface, the About link was the same as the Source link. It has been replaced from <https://github.com/discourse/discourse-groups-css-classes-in-body> to <https://meta.discourse.org/t/css-classes-for-current-users-groups/226068>.
Same in the readme, which previously linked to <https://meta.discourse.org/>, now <https://meta.discourse.org/t/css-classes-for-current-users-groups/226068>.